### PR TITLE
Add Theme Support for Python 2.7

### DIFF
--- a/plexapi/audio.py
+++ b/plexapi/audio.py
@@ -7,7 +7,8 @@ from plexapi.base import Playable, PlexPartialObject
 from plexapi.exceptions import BadRequest
 from plexapi.mixins import AdvancedSettingsMixin, ArtUrlMixin, ArtMixin, PosterUrlMixin, PosterMixin
 from plexapi.mixins import RatingMixin, SplitMergeMixin, UnmatchMatchMixin
-from plexapi.mixins import CollectionMixin, CountryMixin, GenreMixin, LabelMixin, MoodMixin, SimilarArtistMixin, StyleMixin
+from plexapi.mixins import CollectionMixin, CountryMixin, GenreMixin, LabelMixin, MoodMixin, SimilarArtistMixin, \
+    StyleMixin, ThemeMixin, ThemeUrlMixin
 from plexapi.playlist import Playlist
 
 
@@ -126,7 +127,7 @@ class Audio(PlexPartialObject):
 
 @utils.registerPlexObject
 class Artist(Audio, AdvancedSettingsMixin, ArtMixin, PosterMixin, RatingMixin, SplitMergeMixin, UnmatchMatchMixin,
-        CollectionMixin, CountryMixin, GenreMixin, MoodMixin, SimilarArtistMixin, StyleMixin):
+             CollectionMixin, CountryMixin, GenreMixin, MoodMixin, SimilarArtistMixin, StyleMixin, ThemeMixin):
     """ Represents a single Artist.
 
         Attributes:
@@ -141,6 +142,7 @@ class Artist(Audio, AdvancedSettingsMixin, ArtMixin, PosterMixin, RatingMixin, S
             locations (List<str>): List of folder paths where the artist is found on disk.
             similar (List<:class:`~plexapi.media.Similar`>): List of similar objects.
             styles (List<:class:`~plexapi.media.Style`>): List of style objects.
+            theme (str): URL to theme resource (/library/metadata/<ratingkey>/theme/<themeid>).
     """
     TAG = 'Directory'
     TYPE = 'artist'
@@ -156,6 +158,7 @@ class Artist(Audio, AdvancedSettingsMixin, ArtMixin, PosterMixin, RatingMixin, S
         self.locations = self.listAttrs(data, 'path', etag='Location')
         self.similar = self.findItems(data, media.Similar)
         self.styles = self.findItems(data, media.Style)
+        self.theme = data.attrib.get('theme')
 
     def __iter__(self):
         for album in self.albums():
@@ -230,8 +233,8 @@ class Artist(Audio, AdvancedSettingsMixin, ArtMixin, PosterMixin, RatingMixin, S
 
 
 @utils.registerPlexObject
-class Album(Audio, ArtMixin, PosterMixin, RatingMixin, UnmatchMatchMixin,
-        CollectionMixin, GenreMixin, LabelMixin, MoodMixin, StyleMixin):
+class Album(Audio, ArtMixin, PosterMixin, RatingMixin, UnmatchMatchMixin, CollectionMixin, GenreMixin, LabelMixin,
+            MoodMixin, StyleMixin, ThemeUrlMixin):
     """ Represents a single Album.
 
         Attributes:
@@ -248,6 +251,7 @@ class Album(Audio, ArtMixin, PosterMixin, RatingMixin, UnmatchMatchMixin,
             parentGuid (str): Plex GUID for the album artist (plex://artist/5d07bcb0403c64029053ac4c).
             parentKey (str): API URL of the album artist (/library/metadata/<parentRatingKey>).
             parentRatingKey (int): Unique key identifying the album artist.
+            parentTheme (str): URL to show theme resource (/library/metadata/<parentRatingkey>/theme/<themeid>).
             parentThumb (str): URL to album artist thumbnail image (/library/metadata/<parentRatingKey>/thumb/<thumbid>).
             parentTitle (str): Name of the album artist.
             rating (float): Album rating (7.9; 9.8; 8.1).
@@ -274,6 +278,7 @@ class Album(Audio, ArtMixin, PosterMixin, RatingMixin, UnmatchMatchMixin,
         self.parentGuid = data.attrib.get('parentGuid')
         self.parentKey = data.attrib.get('parentKey')
         self.parentRatingKey = utils.cast(int, data.attrib.get('parentRatingKey'))
+        self.parentTheme = data.attrib.get('parentTheme')
         self.parentThumb = data.attrib.get('parentThumb')
         self.parentTitle = data.attrib.get('parentTitle')
         self.rating = utils.cast(float, data.attrib.get('rating'))
@@ -337,8 +342,7 @@ class Album(Audio, ArtMixin, PosterMixin, RatingMixin, UnmatchMatchMixin,
 
 
 @utils.registerPlexObject
-class Track(Audio, Playable, ArtUrlMixin, PosterUrlMixin, RatingMixin,
-        CollectionMixin, MoodMixin):
+class Track(Audio, Playable, ArtUrlMixin, PosterUrlMixin, RatingMixin, CollectionMixin, MoodMixin, ThemeUrlMixin):
     """ Represents a single Track.
 
         Attributes:
@@ -351,6 +355,8 @@ class Track(Audio, Playable, ArtUrlMixin, PosterUrlMixin, RatingMixin,
             grandparentGuid (str): Plex GUID for the album artist (plex://artist/5d07bcb0403c64029053ac4c).
             grandparentKey (str): API URL of the album artist (/library/metadata/<grandparentRatingKey>).
             grandparentRatingKey (int): Unique key identifying the album artist.
+            grandparentTheme (str): URL to show theme resource
+                (/library/metadata/<grandparentRatingkey>/theme/<themeid>).
             grandparentThumb (str): URL to album artist thumbnail image
                 (/library/metadata/<grandparentRatingKey>/thumb/<thumbid>).
             grandparentTitle (str): Name of the album artist for the track.
@@ -381,6 +387,7 @@ class Track(Audio, Playable, ArtUrlMixin, PosterUrlMixin, RatingMixin,
         self.grandparentGuid = data.attrib.get('grandparentGuid')
         self.grandparentKey = data.attrib.get('grandparentKey')
         self.grandparentRatingKey = utils.cast(int, data.attrib.get('grandparentRatingKey'))
+        self.grandparentTheme = data.attrib.get('grandparentTheme')
         self.grandparentThumb = data.attrib.get('grandparentThumb')
         self.grandparentTitle = data.attrib.get('grandparentTitle')
         self.media = self.findItems(data, media.Media)

--- a/plexapi/media.py
+++ b/plexapi/media.py
@@ -1106,3 +1106,29 @@ class AgentMediaType(Agent):
     @deprecated('use "languageCodes" instead')
     def languageCode(self):
         return self.languageCodes
+
+
+class Theme(PlexObject):
+    """ Class for Theme objects.
+
+        Attributes:
+            TAG (str): 'Track'
+            key (str): API URL (/library/metadata/<ratingKey>/file?url=<themeid>).
+            ratingKey (str): Unique key identifying the theme.
+            selected (bool): True if the theme is currently selected.
+    """
+    TAG = 'Track'
+
+    def _loadData(self, data):
+        self._data = data
+        self.key = data.attrib.get('key')
+        self.ratingKey = data.attrib.get('ratingKey')
+        self.selected = utils.cast(bool, data.attrib.get('selected'))
+
+    def select(self):
+        key = self._initpath[:-1]
+        data = '%s?url=%s' % (key, quote_plus(self.ratingKey))
+        try:
+            self._server.query(data, method=self._server._session.put)
+        except xml.etree.ElementTree.ParseError:
+            pass

--- a/plexapi/mixins.py
+++ b/plexapi/mixins.py
@@ -209,6 +209,49 @@ class PosterMixin(PosterUrlMixin):
         self._edit(**{'thumb.locked': 0})
 
 
+class ThemeUrlMixin(object):
+    """ Mixin for Plex objects that can have a theme url. """
+
+    @property
+    def themeUrl(self):
+        """ Return the theme url for the Plex object. """
+        theme = self.firstAttr('theme', 'parentTheme', 'grandparentTheme')
+        return self._server.url(theme, includeToken=True) if theme else None
+
+
+class ThemeMixin(ThemeUrlMixin):
+    """ Mixin for Plex objects that can have themes. """
+
+    def themes(self):
+        """ Returns list of available :class:`~plexapi.media.Theme` objects. """
+        return self.fetchItems('/library/metadata/%s/themes' % self.ratingKey, cls=media.Theme)
+
+    def uploadTheme(self, url=None, filepath=None):
+        """ Upload a theme from url or filepath.
+
+            Warning: Themes cannot be deleted using PlexAPI!
+
+            Parameters:
+                url (str): The full URL to the theme to upload.
+                filepath (str): The full file path to the theme to upload.
+        """
+        if url:
+            key = '/library/metadata/%s/themes?url=%s' % (self.ratingKey, quote_plus(url))
+            self._server.query(key, method=self._server._session.post)
+        elif filepath:
+            key = '/library/metadata/%s/themes?' % self.ratingKey
+            data = open(filepath, 'rb').read()
+            self._server.query(key, method=self._server._session.post, data=data)
+
+    def setTheme(self, theme):
+        """ Set the theme for a Plex object.
+
+            Parameters:
+                theme (:class:`~plexapi.media.Theme`): The poster object to select.
+        """
+        theme.select()
+
+
 class RatingMixin(object):
     """ Mixin for Plex objects that can have user star ratings. """
 

--- a/plexapi/mixins.py
+++ b/plexapi/mixins.py
@@ -161,7 +161,7 @@ class PosterUrlMixin(object):
     @property
     def thumbUrl(self):
         """ Return the thumb url for the Plex object. """
-        thumb = self.firstAttr('thumb', 'parentThumb', 'granparentThumb')
+        thumb = self.firstAttr('thumb', 'parentThumb', 'grandparentThumb')
         return self._server.url(thumb, includeToken=True) if thumb else None
 
     @property

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -7,7 +7,7 @@ from plexapi.base import Playable, PlexPartialObject
 from plexapi.exceptions import BadRequest
 from plexapi.mixins import AdvancedSettingsMixin, ArtUrlMixin, ArtMixin, BannerMixin, CollectionMixin, CountryMixin, \
     DirectorMixin, GenreMixin, LabelMixin, PosterUrlMixin, PosterMixin, ProducerMixin, RatingMixin, SplitMergeMixin, \
-    ThemeMixin, UnmatchMatchMixin, WriterMixin
+    ThemeMixin, ThemeUrlMixin, UnmatchMatchMixin, WriterMixin
 
 
 class Video(PlexPartialObject):
@@ -577,7 +577,7 @@ class Show(Video, AdvancedSettingsMixin, ArtMixin, BannerMixin, PosterMixin, Rat
 
 
 @utils.registerPlexObject
-class Season(Video, ArtMixin, PosterMixin, RatingMixin, CollectionMixin, ThemeMixin):
+class Season(Video, ArtMixin, PosterMixin, RatingMixin, CollectionMixin, ThemeUrlMixin):
     """ Represents a single Show Season (including all episodes).
 
         Attributes:
@@ -713,7 +713,7 @@ class Season(Video, ArtMixin, PosterMixin, RatingMixin, CollectionMixin, ThemeMi
 
 @utils.registerPlexObject
 class Episode(Video, Playable, ArtMixin, PosterMixin, RatingMixin, CollectionMixin, DirectorMixin, WriterMixin,
-              ThemeMixin):
+              ThemeUrlMixin):
     """ Represents a single Shows Episode.
 
         Attributes:

--- a/plexapi/video.py
+++ b/plexapi/video.py
@@ -5,9 +5,9 @@ from urllib.parse import quote_plus, urlencode
 from plexapi import library, media, utils
 from plexapi.base import Playable, PlexPartialObject
 from plexapi.exceptions import BadRequest
-from plexapi.mixins import AdvancedSettingsMixin, ArtUrlMixin, ArtMixin, BannerMixin, PosterUrlMixin, PosterMixin
-from plexapi.mixins import RatingMixin, SplitMergeMixin, UnmatchMatchMixin
-from plexapi.mixins import CollectionMixin, CountryMixin, DirectorMixin, GenreMixin, LabelMixin, ProducerMixin, WriterMixin
+from plexapi.mixins import AdvancedSettingsMixin, ArtUrlMixin, ArtMixin, BannerMixin, CollectionMixin, CountryMixin, \
+    DirectorMixin, GenreMixin, LabelMixin, PosterUrlMixin, PosterMixin, ProducerMixin, RatingMixin, SplitMergeMixin, \
+    ThemeMixin, UnmatchMatchMixin, WriterMixin
 
 
 class Video(PlexPartialObject):
@@ -261,8 +261,9 @@ class Video(PlexPartialObject):
 
 
 @utils.registerPlexObject
-class Movie(Video, Playable, AdvancedSettingsMixin, ArtMixin, PosterMixin, RatingMixin, SplitMergeMixin, UnmatchMatchMixin,
-        CollectionMixin, CountryMixin, DirectorMixin, GenreMixin, LabelMixin, ProducerMixin, WriterMixin):
+class Movie(Video, Playable, AdvancedSettingsMixin, ArtMixin, PosterMixin, RatingMixin, SplitMergeMixin,
+            UnmatchMatchMixin, CollectionMixin, CountryMixin, DirectorMixin, GenreMixin, LabelMixin, ProducerMixin,
+            WriterMixin, ThemeMixin):
     """ Represents a single Movie.
 
         Attributes:
@@ -293,6 +294,7 @@ class Movie(Video, Playable, AdvancedSettingsMixin, ArtMixin, PosterMixin, Ratin
             similar (List<:class:`~plexapi.media.Similar`>): List of Similar objects.
             studio (str): Studio that created movie (Di Bonaventura Pictures; 21 Laps Entertainment).
             tagline (str): Movie tag line (Back 2 Work; Who says men can't change?).
+            theme (str): URL to theme resource (/library/metadata/<ratingkey>/theme/<themeid>).
             useOriginalTitle (int): Setting that indicates if the original title is used for the movie
                 (-1 = Library default, 0 = No, 1 = Yes).
             viewOffset (int): View offset in milliseconds.
@@ -331,6 +333,7 @@ class Movie(Video, Playable, AdvancedSettingsMixin, ArtMixin, PosterMixin, Ratin
         self.similar = self.findItems(data, media.Similar)
         self.studio = data.attrib.get('studio')
         self.tagline = data.attrib.get('tagline')
+        self.theme = data.attrib.get('theme')
         self.useOriginalTitle = utils.cast(int, data.attrib.get('useOriginalTitle', '-1'))
         self.viewOffset = utils.cast(int, data.attrib.get('viewOffset', 0))
         self.writers = self.findItems(data, media.Writer)
@@ -377,8 +380,8 @@ class Movie(Video, Playable, AdvancedSettingsMixin, ArtMixin, PosterMixin, Ratin
 
 
 @utils.registerPlexObject
-class Show(Video, AdvancedSettingsMixin, ArtMixin, BannerMixin, PosterMixin, RatingMixin, SplitMergeMixin, UnmatchMatchMixin,
-        CollectionMixin, GenreMixin, LabelMixin):
+class Show(Video, AdvancedSettingsMixin, ArtMixin, BannerMixin, PosterMixin, RatingMixin, SplitMergeMixin,
+           UnmatchMatchMixin, CollectionMixin, GenreMixin, LabelMixin, ThemeMixin):
     """ Represents a single Show (including all seasons and episodes).
 
         Attributes:
@@ -574,7 +577,7 @@ class Show(Video, AdvancedSettingsMixin, ArtMixin, BannerMixin, PosterMixin, Rat
 
 
 @utils.registerPlexObject
-class Season(Video, ArtMixin, PosterMixin, RatingMixin, CollectionMixin):
+class Season(Video, ArtMixin, PosterMixin, RatingMixin, CollectionMixin, ThemeMixin):
     """ Represents a single Show Season (including all episodes).
 
         Attributes:
@@ -709,8 +712,8 @@ class Season(Video, ArtMixin, PosterMixin, RatingMixin, CollectionMixin):
 
 
 @utils.registerPlexObject
-class Episode(Video, Playable, ArtMixin, PosterMixin, RatingMixin,
-        CollectionMixin, DirectorMixin, WriterMixin):
+class Episode(Video, Playable, ArtMixin, PosterMixin, RatingMixin, CollectionMixin, DirectorMixin, WriterMixin,
+              ThemeMixin):
     """ Represents a single Shows Episode.
 
         Attributes:


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed.
- Closely replicates Poster Mixins for Themes
  - list themes
  - upload theme
  - set theme
  - get theme url with token
- Add Theme attribute for movies in video.py
- Fixes typo in PosterUrlMixin class (`grandparentThumb`)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
- [ ] I have added tests when applicable
